### PR TITLE
Note on how Netlify preview deployment is accessible

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,4 @@ This is the SRO Knowledgebase, which can be [viewed here](https://sro.netlify.co
 It is built using [Mkdocs](https://www.mkdocs.org/) and should be as easy as writing Markdown.
 
 It is published automagically using Netlify.
+When you push changes and create a pull request, Netlify will create a preview version of the site accessible with a link from the pull request page.


### PR DESCRIPTION
Just wanted to clarify the Netlify preview deployment pipeline, because I didn't know it before and expect others won't either